### PR TITLE
[IMP] stock_procurement_calendar_purchase: split and improme procurem…

### DIFF
--- a/stock_procurement_calendar_purchase/models/procurement.py
+++ b/stock_procurement_calendar_purchase/models/procurement.py
@@ -9,6 +9,12 @@ class ProcurementOrder(models.Model):
 
     _inherit = 'procurement.order'
 
+    @api.multi
+    def run(self, autocommit=False):
+        # preload data for def check
+        self.mapped('orderpoint_id.procurement_calendar_id')
+        return super(ProcurementOrder, self).run(autocommit)
+
     def _procurement_from_orderpoint_get_groups(self, orderpoint_ids):
         orderpoint = self.env['stock.warehouse.orderpoint'].browse(
             orderpoint_ids[0])

--- a/stock_procurement_calendar_purchase/views/stock_warehouse_orderpoint.xml
+++ b/stock_procurement_calendar_purchase/views/stock_warehouse_orderpoint.xml
@@ -26,7 +26,6 @@
         <field name="inherit_id" ref="stock.view_warehouse_orderpoint_tree"/>
         <field name="arch" type="xml">
             <field name="product_max_qty" position="after">
-                <field name="procure_recommended_qty"/>
                 <field name="expected_seller_id"/>
             </field>
         </field>


### PR DESCRIPTION
…ent attedance compute functions


- Le scheduler n'utilise pas le champs procure_recommended_qty. 
Donc on le recalcule pour rien via la fonction compute. -> il faut splitter la fonction _compute_procure_recommended en 2 pour séparer les champs.

- dans la fonction _compute_procure_recommended: n'appeler qu'une fois la fct subtract_procurements_from_orderpoints

En parallèle, j'ai créé une PR sur l'oca pour optimiser la fonction subtract_procurements_from_orderpoints:
https://github.com/OCA/stock-logistics-warehouse/pull/397
