### PR TITLE
[FIX] stock_procurement_calendar_purchase fix compute newId

### DIFF
--- a/stock_procurement_calendar_purchase/models/stock_warehouse_orderpoint.py
+++ b/stock_procurement_calendar_purchase/models/stock_warehouse_orderpoint.py
@@ -248,8 +248,14 @@ class StockWarehouseOrderpoint(models.Model):
         :param limit:
         :return: N/A
         """
-        subtract_procurements = self.subtract_procurements_from_orderpoints()
-        for orderpoint in self:
+        recs = self
+        for rec in recs:
+            if isinstance(rec.id, models.NewId):
+                recs -= rec
+        if not recs:
+            return
+        subtract_procurements = recs.subtract_procurements_from_orderpoints()
+        for orderpoint in recs:
             orderpoint.substract_quantity = subtract_procurements.get(
                 orderpoint.id)
             procurement_date = fields.Datetime.from_string(


### PR DESCRIPTION
https://wink.plan.io/issues/3899
Fix this error when you try to create a stock orderpoint:

 File "/home/odoo-colombo-recette/instance/venv-2.0.3/lib/python2.7/site-packages/odoo/fields.py", line 1037, in determine_draft_value
    self._compute_value(record)
  File "/home/odoo-colombo-recette/instance/venv-2.0.3/lib/python2.7/site-packages/odoo/fields.py", line 971, in _compute_value
    getattr(records, self.compute)()
  File "/home/odoo-colombo-recette/instance/venv-2.0.3/lib/python2.7/site-packages/odoo/addons/stock_procurement_calendar_purchase/models/stock_warehouse_orderpoint.py", line 251, in _compute_procure_recommended
    subtract_procurements = self.subtract_procurements_from_orderpoints()
  File "/home/odoo-colombo-recette/instance/venv-2.0.3/lib/python2.7/site-packages/odoo/addons/purchase_packaging/models/procurement_order.py", line 52, in subtract_procurements_from_orderpoints
    res = super(Orderpoint, self).subtract_procurements_from_orderpoints()
  File "/home/odoo-colombo-recette/instance/venv-2.0.3/lib/python2.7/site-packages/odoo/addons/stock/models/stock_warehouse.py", line 832, in subtract_procurements_from_orderpoints
    """, (tuple(self.ids),))
  File "/home/odoo-colombo-recette/instance/venv-2.0.3/lib/python2.7/site-packages/odoo/sql_db.py", line 154, in wrapper
    return f(self, *args, **kwargs)
  File "/home/odoo-colombo-recette/instance/venv-2.0.3/lib/python2.7/site-packages/odoo/sql_db.py", line 231, in execute
    res = self._obj.execute(query, params)
ProgrammingError: syntax error at or near ")"
LINE 9:                 AND orderpoint.id IN ()
                                              ^


